### PR TITLE
Implement alias-like setting salias

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Apply alias to sub-commands
 ## Description  
 I don't like longer commands. So I often use `alias`.  
 Just like following:  
+
 ``` sh
 $ alias d=docker
 $ d ps
@@ -19,30 +20,15 @@ However, `alias` command can apply for command only.
 `salias` means sub-alias. `salias` makes it possible to apply alias to sub-commands.  
 
 ## Example
-~/salias.toml
-``` toml 
-[go]
-i = "install"
-b = "build"
-r = "run"
-
-[docker]
-i = "image"
-c = "container"
-
-[docker-compose]
-l = "logs -f"
-```
-
 ``` bash
+$ salias go i=install
+$ salias docker c=container
+$ exec $SHELL # reload the shell
+
 $ go i github.com/golang/go
 # `go install github.com/golang/go` 
 
-$ docker i ls
-# `docker image ls`
-
-$ alias d=docker
-$ d c ls
+$ docker c ls
 # `docker container ls`
 ```
 
@@ -52,26 +38,36 @@ $ d c ls
 
 ## Installation
 ``` sh
+$ export GOPATH=~/go # if $GOPATH is not set
 $ go get github.com/lycoris0731/salias
+$ sudo ln $GOPATH/bin/salias /usr/bin/
 ```
 
 ## Usage
 ### Set sub-alias definition file
-Please set the file to one of following.  
+Please create one of these files:  
 - $SALIAS_PATH
+
 - $XDG_CONFIG_HOME/salias/salias.toml
+
 - $HOME/salias.toml
+
+Then use `salias <command> <subalias>=<subcommand>` to set sub-alias. Or edit `salias.toml` manually.
+
+### Make sub-alias initializes automatically
 
 Add following command.  
 
 `.bashrc` or `.zshrc`.  
+
 ``` sh
-source <(salias __init__)
+source <(salias --init) # or `salias -i` for short
 ```
 
 `config.fish`
+
 ``` sh
-source (salias __init__ | psub)
+source (salias --init | psub)
 ```
 
 ## How It Works
@@ -79,9 +75,9 @@ When initialization, `salias` registers the command as salias's alias.
 ``` sh
 # [go]
 # b = "build"
-$ source <(salias __init__)
+$ source <(salias --init)
 $ type go
-go is an alias for salias go
+go is an alias for salias --run go
 ```
 
 `salias` find sub-alias that is sub-command of passed command as arguments.  

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func run(cmdIO *commandIO, args []string) (int, error) {
 func initSalias() (int, error) {
 	cmds, err := getCmds()
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to generate init script")
+		return 1, errors.Wrap(err, "failed to generate init script")
 	}
 
 	var aliases string

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func initSalias() (int, error) {
 
 	var aliases string
 	for key := range cmds {
-		aliases += fmt.Sprintf("alias %s='salias -r %s'\n", key, key)
+		aliases += fmt.Sprintf("alias %s='salias --run %s'\n", key, key)
 	}
 	fmt.Print(aliases)
 	return 0, nil


### PR DESCRIPTION
# [genelocated/salias](https://github.com/genelocated/salias/tree/85567de0d3f8f98ad679d82cd34e5f82fd032b21) on dev

When we use alias, we do something like this:

```sh
$ alias d=docker
```

So why not add this to salias:

```sh
$ salias docker i=image
```

That's what I did.

Other changes:
* Original salias use `salias <cmd>` to run commands, I changed it to `salias --run <cmd>` or `salias -r <cmd>`.
* Also, I add `--init` and `-i` flags, while original `__init__` flag is still preserved.
* Add type `commands` and `command` to reduce the usage of `map[string]interface{}` in code.

---

:link: Attach: [salias.tar.gz](https://github.com/ktr0731/salias/files/2385360/salias.tar.gz)